### PR TITLE
Updated Node version to 10

### DIFF
--- a/firebase-func/functions/package.json
+++ b/firebase-func/functions/package.json
@@ -9,6 +9,9 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },
+  "engines": {
+	"node": "10"
+  },
   "dependencies": {
     "firebase-admin": "~6.4.0",
     "nodemailer": "^5.0.0",


### PR DESCRIPTION
> [Action Required] Cloud Functions for Firebase support for Node 6 runtime will shut down, please update to a newer version before September 5, 2020

Updated the package.json so we don't get that error anymore, just needed to add the property "engines" so firebase knows which version of node to use.